### PR TITLE
Ability to add additional monitors to existing Splunk installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ splunkforwarder_outputs: |
 # add all the input you want here, basic default
 splunkforwarder_inputs: |
   [default]
-  index         = default
+  index         = {{ splunkforwarder_default_index }}
 
   [monitor://$SPLUNK_HOME/var/log/splunk]
   index = _internal

--- a/README.md
+++ b/README.md
@@ -75,3 +75,4 @@ Add additional monitors to an existing installation
 
   roles: 
     - overipio.splunk-universalforwarder
+```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ splunkforwarder_md5: 'md5:e8468b95b4ca03f73f33714a4430c82e'
 splunkforwarder_user: admin
 splunkforwarder_pass: changeme
 
+# DEFAULT INDEX
+splunkforwarder_default_index: default
+
 # CONFIG FILE CONTENTS
 # Likely a better way to do this, but to get started, here are the config files
 # we want to deploy to the system
@@ -58,3 +61,17 @@ Example Playbook
   roles:
     - overipio.splunk-universalforwarder
 ```
+
+Add additional monitors to an existing installation
+
+```yaml
+- hosts: servers
+  vars:
+    - splunkforwarder_inputs_monitor:
+        - path: "/opt/applications/helloworld/*.log"
+          sourcetype: application_log
+          index: differentindex
+        - path: "/opt/foo/bar.log"
+
+  roles: 
+    - overipio.splunk-universalforwarder

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,9 @@ splunkforwarder_get_via_curl: no
 splunkforwarder_user: admin
 splunkforwarder_pass: changeme
 
+# DEFAULT INDEX
+splunkforwarder_default_index: default
+
 # CONFIG FILE CONTENTS
 # Likely a better way to do this, but to get started, here are the config files
 # we want to deploy to the system
@@ -30,7 +33,7 @@ splunkforwarder_outputs: |
 # add all the input you want here, basic default
 splunkforwarder_inputs: |
   [default]
-  index         = default
+  index         = {{ splunkforwarder_default_index }}
 
   [monitor://$SPLUNK_HOME/var/log/splunk]
   index = _internal

--- a/tasks/inputs.yml
+++ b/tasks/inputs.yml
@@ -1,16 +1,26 @@
 ---
 # playbook copies over inputs.conf for the uf
 
-- name: template out inputs.conf 
+- name: create inputs.conf
   become: yes
   tags:
    - configure
-  template: 
-    src: opt/splunkforwarder/etc/system/local/inputs.conf 
-    dest: "{{ splunkforwarder_path }}/etc/system/local" 
-    owner: "{{ splunkforwarder_system_user }}" 
-    group: "{{ splunkforwarder_system_user }}" 
+  file:
+    path: "{{ splunkforwarder_path }}/etc/system/local/inputs.conf"
+    state: touch
+    owner: "{{ splunkforwarder_system_user }}"
+    group: "{{ splunkforwarder_system_user }}"
     mode: 0755
+
+- name: default inputs.conf 
+  become: yes
+  tags:
+   - configure
+  blockinfile:
+    dest: "{{ splunkforwarder_path }}/etc/system/local/inputs.conf"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK inputs.conf"
+    block: |
+      {{ splunkforwarder_inputs }}
   notify: restart splunk
 
 - name: add monitors to inputs.conf
@@ -25,6 +35,5 @@
       {% if item.index is defined %}index = {{ item.index }} {% endif %} 
       {% if item.sourcetype is defined %}sourcetype = {{ item.sourcetype }} {% endif %} 
       {% if item.source is defined %}source = {{ item.source }} {% endif %} 
-  with_items: "{{ splunkforwarder_inputs_monitor }}"
-  when: splunkforwarder_inputs_monitor is defined
+  with_items: "{{ splunkforwarder_inputs_monitor|default([]) }}"
   notify: restart splunk

--- a/tasks/inputs.yml
+++ b/tasks/inputs.yml
@@ -13,3 +13,18 @@
     mode: 0755
   notify: restart splunk
 
+- name: add monitors to inputs.conf
+  become: yes
+  tags:
+   - configure
+  blockinfile:
+    dest: "{{ splunkforwarder_path }}/etc/system/local/inputs.conf"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK {{item.path}}"
+    block: |
+      [monitor://{{ item.path }}]
+      {% if item.index is defined %}index = {{ item.index }} {% endif %} 
+      {% if item.sourcetype is defined %}sourcetype = {{ item.sourcetype }} {% endif %} 
+      {% if item.source is defined %}source = {{ item.source }} {% endif %} 
+  with_items: "{{ splunkforwarder_inputs_monitor }}"
+  when: splunkforwarder_inputs_monitor is defined
+  notify: restart splunk

--- a/templates/opt/splunkforwarder/etc/system/local/inputs.conf
+++ b/templates/opt/splunkforwarder/etc/system/local/inputs.conf
@@ -1,1 +1,0 @@
-{{ splunkforwarder_inputs }}

--- a/templates/opt/splunkforwarder/etc/system/local/inputs.conf
+++ b/templates/opt/splunkforwarder/etc/system/local/inputs.conf
@@ -1,2 +1,1 @@
-
 {{ splunkforwarder_inputs }}


### PR DESCRIPTION
There's a couple of bits in this change;

- Allow you to create a monitor using the variable `splunkforwarder_inputs_monitor` which appends to inputs.conf
- No longer recreates inputs.conf on each run, instead it uses `blockinfile`, also creates input.conf if it doesn't exist. Useful if you have multiple playbooks against a single server and don't want to override any config values in input.conf from another playbook. Another advantage of using blockinfile here is that you can remove a block via the marker (eg. a monitor that is no longer required)
- Define the default index in a playbook via `splunkforwarder_default_index`

This change still allows monitors to be defined in `splunkforwarder_inputs` so won't affect any existing users.

Example;
 
`playbook.yml`
```yaml
- hosts: servers
  vars:
    - splunkforwarder_inputs_monitor:
        - path: "/opt/applications/helloworld/*.log"
          sourcetype: application_log
          index: differentindex
        - path: "/opt/foo/bar.log"
  roles: 
    - overipio.splunk-universalforwarder
```

`/opt/splunkforwarder/etc/system/local/inputs.conf`
```
# BEGIN ANSIBLE MANAGED BLOCK inputs.conf
[default]
index         = default

[monitor://$SPLUNK_HOME/var/log/splunk]
index = _internal

# END ANSIBLE MANAGED BLOCK inputs.conf
# BEGIN ANSIBLE MANAGED BLOCK /opt/applications/helloworld/*.log
[monitor:///opt/applications/helloworld/*.log]
index = differentindex
sourcetype = application_log

# END ANSIBLE MANAGED BLOCK /opt/applications/helloworld/*.log
# BEGIN ANSIBLE MANAGED BLOCK /opt/foo/bar.log
[monitor:///opt/foo/bar.log]

# END ANSIBLE MANAGED BLOCK /opt/foo/bar.log
```

If I were to then add `splunkforwarder_inputs_monitor` to another playbook and run it against the same host, the new `monitor://` will get appended to the end of inputs.conf