### PR TITLE
Deployment server

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ splunkforwarder_md5: 'md5:e8468b95b4ca03f73f33714a4430c82e'
 splunkforwarder_user: admin
 splunkforwarder_pass: changeme
 
+# DEPLOYMENT SERVER
+# Set if using a Splunk Deploment Server
+# splunkforwarder_deployment_server:
+
 # CONFIG FILE CONTENTS
 # Likely a better way to do this, but to get started, here are the config files
 # we want to deploy to the system

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ splunkforwarder_user: admin
 splunkforwarder_pass: changeme
 
 # DEPLOYMENT SERVER
-# Set if using a Splunk Deploment Server
+# Set if using a Splunk Deployment Server
 # splunkforwarder_deployment_server:
 
 # CONFIG FILE CONTENTS

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,10 @@ splunkforwarder_get_via_curl: no
 splunkforwarder_user: admin
 splunkforwarder_pass: changeme
 
+# DEPLOYMENT SERVER
+# Set if using a Splunk Deploment Server
+# splunkforwarder_deployment_server:
+
 # CONFIG FILE CONTENTS
 # Likely a better way to do this, but to get started, here are the config files
 # we want to deploy to the system

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,7 @@ splunkforwarder_user: admin
 splunkforwarder_pass: changeme
 
 # DEPLOYMENT SERVER
-# Set if using a Splunk Deploment Server
+# Set if using a Splunk Deployment Server
 # splunkforwarder_deployment_server:
 
 # CONFIG FILE CONTENTS

--- a/tasks/deploymentclient.yml
+++ b/tasks/deploymentclient.yml
@@ -1,0 +1,15 @@
+---
+# playbook copies over outputs.yml for the uf
+
+- name: template out deploymentclient.conf
+  become: yes
+  tags:
+   - configure
+  template: 
+    src: opt/splunkforwarder/etc/system/local/deploymentclient.conf 
+    dest: "{{ splunkforwarder_path }}/etc/system/local" 
+    owner: "{{ splunkforwarder_system_user }}" 
+    group: "{{ splunkforwarder_system_user }}" 
+    mode: 0755
+  when: splunkforwarder_deployment_server is defined
+  notify: restart splunk

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,3 +5,4 @@
 - include: security.yml
 - include: outputs.yml
 - include: inputs.yml
+- include: deploymentclient.yml

--- a/templates/opt/splunkforwarder/etc/system/local/deploymentclient.conf
+++ b/templates/opt/splunkforwarder/etc/system/local/deploymentclient.conf
@@ -1,0 +1,4 @@
+[deployment-client]
+
+[target-broker:deploymentServer]
+targetUri= {{ splunkforwarder_deployment_server }} 


### PR DESCRIPTION
Additional task to setup deploymentserver.conf if `splunkforwarder_deployment_server` is defined.

http://docs.splunk.com/Documentation/Splunk/6.5.1/Updating/Configuredeploymentclients

